### PR TITLE
Fix path to image.

### DIFF
--- a/plone/formwidget/autocomplete/jquery-autocomplete/jquery.autocomplete.css
+++ b/plone/formwidget/autocomplete/jquery-autocomplete/jquery.autocomplete.css
@@ -35,7 +35,7 @@
 }
 
 .ac_loading {
-	background: white url('indicator.gif') right center no-repeat;
+	background: white url('/++resource++plone.formwidget.autocomplete/indicator.gif') right center no-repeat;
 }
 
 .ac_odd {
@@ -46,3 +46,4 @@
 	background-color: #0A246A;
 	color: white;
 }
+


### PR DESCRIPTION
The image could not be loaded and some products use this these paths. Works in Plone 4.1.6.
