### PR TITLE
Fix ModuleNotFoundError: No module named 'App.class_init'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ New features:
 
 Bug fixes:
 
+- Fix ModuleNotFoundError: No module named 'App.class_init' [krissik]
 - *add item here*
 
 

--- a/plone/formwidget/autocomplete/widget.py
+++ b/plone/formwidget/autocomplete/widget.py
@@ -2,7 +2,7 @@ from AccessControl import getSecurityManager
 from AccessControl import ClassSecurityInfo
 from Acquisition import Explicit
 from Acquisition.interfaces import IAcquirer
-from App.class_init import InitializeClass
+from AccessControl.class_init import InitializeClass
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 import z3c.form.interfaces


### PR DESCRIPTION
see
https://github.com/plone/plone.formwidget.autocomplete/issues/27